### PR TITLE
Add custom_data to create_room and update_room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-server-ruby/compare/1.0.0...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-server-ruby/compare/1.1.0...HEAD)
+
+## [1.1.0](https://github.com/pusher/chatkit-server-ruby/compare/1.0.0...1.1.0) - 2018-11-07
+
+### Additions
+
+- `create_room` and `update_room` accept `custom_data` as part of the `options` hash.
 
 ## [1.0.0](https://github.com/pusher/chatkit-server-ruby/compare/0.7.2...1.0.0) - 2018-10-30
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pusher-chatkit-server (1.0.0)
+    pusher-chatkit-server (1.1.0)
       pusher-platform (~> 0.11.2)
 
 GEM

--- a/chatkit.gemspec
+++ b/chatkit.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'pusher-chatkit-server'
-  s.version     = '1.0.0'
+  s.version     = '1.1.0'
   s.licenses    = ['MIT']
   s.summary     = 'Pusher Chatkit Ruby SDK'
   s.authors     = ['Pusher']

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -206,6 +206,8 @@ module Chatkit
         name: options[:name],
         private: options[:private] || false
       }
+      
+      body[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       unless options[:user_ids].nil?
         body[:user_ids] = options[:user_ids]
@@ -227,6 +229,7 @@ module Chatkit
       payload = {}
       payload[:name] = options[:name] unless options[:name].nil?
       payload[:private] = options[:private] unless options[:private].nil?
+      payload[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       api_request({
         method: "PUT",

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -385,6 +385,22 @@ describe Chatkit::Client do
         expect(room_res[:body][:private]).to be true
         expect(room_res[:body][:member_user_ids] - [user_id, user_id2]).to be_empty
       end
+
+      it "a creator_id, name and custom_data are provided" do
+      	user_id = SecureRandom.uuid
+        res = @chatkit.create_user({ id: user_id, name: 'Ham' })
+        expect(res[:status]).to eq 201
+
+        room_res = @chatkit.create_room({
+          creator_id: user_id,
+          name: 'my room',
+          custom_data: { foo: 'bar' }
+        })
+        expect(room_res[:status]).to eq 201
+        expect(room_res[:body]).to have_key :id
+        expect(room_res[:body][:name]).to eq 'my room'
+        expect(room_res[:body][:custom_data][:foo]).to eq 'bar'
+      end
     end
   end
 
@@ -406,17 +422,27 @@ describe Chatkit::Client do
         room_res = @chatkit.create_room({
           creator_id: user_id,
           name: 'my room',
-          private: true
+          private: true,
+          custom_data: { foo: 'bar', id: 1 }
         })
         expect(room_res[:status]).to eq 201
 
         update_res = @chatkit.update_room({
           id: room_res[:body][:id],
           name: 'New room name',
-          private: false
+          private: false,
+          custom_data: { foo: 'baz', id: 2 }
         })
         expect(update_res[:status]).to eq 204
         expect(update_res[:body]).to be_nil
+
+        get_room_res = @chatkit.get_room({ id: room_res[:body][:id] })
+        expect(get_room_res[:status]).to eq 200
+        expect(get_room_res[:body][:id]).to eq room_res[:body][:id]
+        expect(get_room_res[:body][:name]).to eq 'New room name'
+        expect(get_room_res[:body][:private]).to eq false
+        expect(get_room_res[:body][:custom_data][:foo]).to eq 'baz'
+        expect(get_room_res[:body][:custom_data][:id]).to eq 2
       end
     end
   end


### PR DESCRIPTION
### What?

Support room `custom_data`

### Why?

Because we want users to be able to use `custom_data` when creating and updating rooms.

----

- [ x] CHANGELOG updated if relevant?
