### PR TITLE
Add :push_notification_title_override to create_room & update_room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...HEAD)
 
+### Additions
+
+- Support for setting push_notification_title_override in create_room
+  and update_room methods.
+
 [1.5.0](https://github.com/pusher/chatkit-server-ruby/compare/1.4.0...1.5.0) - 2019-07-03
 
 ### Additions

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -239,6 +239,7 @@ module Chatkit
       }
 
       body[:id] = options[:id] unless options[:id].nil?
+      body[:push_notification_title_override] = options[:push_notification_title_override] unless options[:push_notification_title_override].nil?
       body[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       unless options[:user_ids].nil?
@@ -261,6 +262,7 @@ module Chatkit
       payload = {}
       payload[:name] = options[:name] unless options[:name].nil?
       payload[:private] = options[:private] unless options[:private].nil?
+      body[:push_notification_title_override] = options[:push_notification_title_override] unless options[:push_notification_title_override].nil?
       payload[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       api_request({

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -262,7 +262,7 @@ module Chatkit
       payload = {}
       payload[:name] = options[:name] unless options[:name].nil?
       payload[:private] = options[:private] unless options[:private].nil?
-      body[:push_notification_title_override] = options[:push_notification_title_override] unless options[:push_notification_title_override].nil?
+      body[:push_notification_title_override] = options[:push_notification_title_override] if options.key?(:push_notification_title_override) # We want to accept nil
       payload[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       api_request({

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -262,7 +262,7 @@ module Chatkit
       payload = {}
       payload[:name] = options[:name] unless options[:name].nil?
       payload[:private] = options[:private] unless options[:private].nil?
-      body[:push_notification_title_override] = options[:push_notification_title_override] if options.key?(:push_notification_title_override) # We want to accept nil
+      payload[:push_notification_title_override] = options[:push_notification_title_override] if options.key?(:push_notification_title_override) # We want to accept nil
       payload[:custom_data] = options[:custom_data] unless options[:custom_data].nil?
 
       api_request({


### PR DESCRIPTION
### What?
Add `:push_notification_title_override` to `create_room` & `update_room`


### Why?
So that users can use this field with this SDK


----

- [ ] CHANGELOG updated if relevant?
