### PR TITLE
Fix customData property not being forwarded when uploading an attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-ruby/compare/1.6.0...HEAD)
 
+### Fixes
+
+- `send_multipart_message` now properly propagates the `name` and `customData` for any attachments provided
+
 [1.6.0](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...1.6.0) - 2019-07-30
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixes
 
-- `send_multipart_message` now properly propagates the `name` and `customData` for any attachments provided
+- `send_multipart_message` now properly propagates the `name` and `custom_data` for any attachments provided
 
 [1.6.0](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...1.6.0) - 2019-07-30
 

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -442,9 +442,7 @@ module Chatkit
           attachment_id = upload_attachment(token, options[:room_id], part)
           {
             type: part[:type],
-            attachment: {id: attachment_id},
-            name: part[:name],
-            customData: part[:customData]
+            attachment: {id: attachment_id}
           }.reject{ |_,v| v.nil? }
         else
           raise Chatkit::MissingParameterError.new("Each part must have one of :file, :content or :url")

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -850,6 +850,7 @@ module Chatkit
         content_type: content_type,
         content_length: content_length,
         name: part[:name],
+        origin: part[:origin],
         custom_data: part[:custom_data]
       }
 

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -850,7 +850,7 @@ module Chatkit
         content_type: content_type,
         content_length: content_length,
         name: part[:name],
-        custom_data: part[:customData]
+        custom_data: part[:custom_data]
       }
 
       attachment_response = api_request({

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -850,7 +850,9 @@ module Chatkit
 
       attachment_req = {
         content_type: content_type,
-        content_length: content_length
+        content_length: content_length,
+        name: part[:name],
+        custom_data: part[:customData]
       }
 
       attachment_response = api_request({

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1277,6 +1277,7 @@ describe Chatkit::Client do
           {type: "binary/octet-stream",
            file: payload,
            name: "random bytes",
+           origin: "https://github.com/pusher/chatkit-server-ruby",
            custom_data: {some: "json", data: 42}
           }
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1059,7 +1059,7 @@ describe Chatkit::Client do
                   {type: "binary/octet-stream",
                    file: Random.new.bytes(100),
                    name: "random bytes",
-                   customData: {some: "json", data: 42}
+                   custom_data: {some: "json", data: 42}
                   }
                  ]
 
@@ -1277,7 +1277,7 @@ describe Chatkit::Client do
           {type: "binary/octet-stream",
            file: payload,
            name: "random bytes",
-           customData: {some: "json", data: 42}
+           custom_data: {some: "json", data: 42}
           }
 
         @chatkit.send_multipart_message(
@@ -1299,7 +1299,7 @@ describe Chatkit::Client do
           expect(message[:parts][0]).to have_key :attachment
           expect(message[:parts][0][:attachment]).to have_key :download_url
           expect(message[:parts][0][:attachment]).to have_key :custom_data
-          expect(message[:parts][0][:attachment][:custom_data]).to eq part[:customData]
+          expect(message[:parts][0][:attachment][:custom_data]).to eq part[:custom_data]
           expect(message[:parts][0][:attachment]).to have_key :name
           expect(message[:parts][0][:attachment][:name]).to eq part[:name]
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1296,7 +1296,13 @@ describe Chatkit::Client do
           expect(message[:room_id]).to eq room_id
           expect(message[:user_id]).to eq user_id
 
-          message_id = message[:id]
+          expect(message[:parts][0]).to have_key :attachment
+          expect(message[:parts][0][:attachment]).to have_key :download_url
+          expect(message[:parts][0][:attachment]).to have_key :custom_data
+          expect(message[:parts][0][:attachment][:custom_data]).to eq part[:customData]
+          expect(message[:parts][0][:attachment]).to have_key :name
+          expect(message[:parts][0][:attachment][:name]).to eq part[:name]
+
           attachment_url = message[:parts][0][:attachment][:download_url]
           response = Excon.new(attachment_url, :omit_default_port => true).get
           expect(response[:status]).to eq 200


### PR DESCRIPTION
### Why?

We want to allow customers to set the customData and name for their attachments when sending a message.

----

- [x] CHANGELOG updated if relevant?
