### PR TITLE
Ruby 2.1.x chokes on quoted symbol in hash literal syntax

### DIFF
--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -691,7 +691,7 @@ module Chatkit
     private
 
     def make_request(instance, options)
-      options.merge!({ headers: { "Content-Type": "application/json" } })
+      options.merge!({ headers: { "Content-Type" => "application/json" } })
       begin
         format_response(instance.request(options))
       rescue PusherPlatform::ErrorResponse => e

--- a/lib/chatkit/client.rb
+++ b/lib/chatkit/client.rb
@@ -691,7 +691,7 @@ module Chatkit
     private
 
     def make_request(instance, options)
-      options.merge!({ headers: { "Content-Type" => "application/json" } })
+      options.merge!({ headers: { :'Content-Type' => 'application/json' } })
       begin
         format_response(instance.request(options))
       rescue PusherPlatform::ErrorResponse => e


### PR DESCRIPTION
### What?

Using `=>` as opposed to `:`.

### Why?

My IDE didn't like it.

----

- [ ] CHANGELOG updated if relevant?
